### PR TITLE
Fix Event Image Positioning

### DIFF
--- a/templates/partials/facebook.event.html.twig
+++ b/templates/partials/facebook.event.html.twig
@@ -9,7 +9,7 @@
     </td>
     {% if showCover %}
       {% if event.cover != '' %}
-        <td class='cover-image' style='background-position-x: {{ event.cover.offset_x }}px; background-position-y: -{{ event.cover.offset_y }}px; background-image: url({{ event.cover.source }});'/></td>
+        <td class='cover-image'/></td>
       {% else %}
         <td class='cover-image'/></td>
       {% endif %}


### PR DESCRIPTION
By default, it's offsetting y -50px.

These settings aren't available from front-end; leads to display issues for properly sized event images.