### PR TITLE
Grab first sub-image if several images on page

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -186,7 +186,11 @@ class FacebookPlugin extends Plugin {
                 $image_html = "";
                 $imageSrc = (property_exists($val, 'attachments')
                     && property_exists($val->attachments->data[0], 'media'))
-                    ? $val->attachments->data[0]->media->image->src : null;
+                    ? $val->attachments->data[0]->media->image->src : (
+                        property_exists($val->attachments->data[0], 'subattachments')
+                        && property_exists($val->attachments->data[0]->subattachments->data[0], 'media')
+                        ? $val->attachments->data[0]->subattachments->data[0]->media->image->src : null
+                    );
 
                 if ($imageSrc) {
                     $image_html = "<figure>";


### PR DESCRIPTION
Currently, when several sub-images are present on a Facebook post, nothing is displayed.

Rather, this grabs the first image in the post to display.

A further development can be to allow users to specify certain images to be chosen if several are present, or even display them all in a slider.