### PR TITLE
Order by unique count id rather than by date

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -175,6 +175,8 @@ class FacebookPlugin extends Plugin {
     private function parsePostResponse($json, $config, $tags_string) {
         $r = array();
         $content = json_decode($json);
+        
+        $count = $config->get('facebook_page_settings.count');
 
         foreach ($content->feed->data as $val) {
             if (property_exists($val, 'message') && $this->tagsExist($tags_string, $val->message)) {
@@ -194,12 +196,14 @@ class FacebookPlugin extends Plugin {
                     $image_html .= "</figure>";
                 }
 
-                $r[$created_at]['time'] = $formatted_date;
-                $r[$created_at]['image'] = $image_html;
-                $r[$created_at]['imageSrc'] = $imageSrc;
-                $r[$created_at]['message'] = nl2br($val->message);
-                $r[$created_at]['link'] = $val->permalink_url;
+                $r[$count]['time'] = $formatted_date;
+                $r[$count]['image'] = $image_html;
+                $r[$count]['imageSrc'] = $imageSrc;
+                $r[$count]['message'] = nl2br($val->message);
+                $r[$count]['link'] = $val->permalink_url;
                 $this->addFeed($r);
+                
+                $count -= 1;
             }
         }
     }


### PR DESCRIPTION
Since the current implementation uses the `created_at` value to store each Facebook post, if two posts have the same date they are stored as one post. (e.g. "This is post 1" posted on **2017-05-21 05:00** and "This is post 2" posted on **2017-05-21 05:00**. Since they both have identical dates, only one of the two posts is displayed.)

Rather, I add a simple counter (which counts in reverse from the user-proposed number of posts) so as to have an independent, unique variable used for ordering.