### PR TITLE
Change 'name' property type from string to array

### DIFF
--- a/facebook.php
+++ b/facebook.php
@@ -263,7 +263,7 @@ class FacebookPlugin extends Plugin {
                 }
                 $r[$start_at]['event_link'] = $val->id;
                 $r[$start_at]['name'] = nl2br($val->name);
-                $r[$start_at]['place'] = '';
+                $r[$start_at]['place'] = array();
                 $r[$start_at]['description'] = '';
                 $r[$start_at]['cover'] = '';
 


### PR DESCRIPTION
Posts worked fine, but when trying to get the events (`{{ facebook_events() }}`), I got this error:

```
Twig_Error_Runtime 
An exception has been thrown during the rendering of a template ("Illegal string offset 'name'").
```
That was because the plugin tried to store `$r[$start_at]['place']['name'] = $val->place->name;` at line 275, while `$r[$start_at]['place']` was a string and not an array. This PR resolves that.
